### PR TITLE
Add initial rockcraft.yaml for BESS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@ CONTRIBUTING.md # Contributing
 
 ```bash
 rockcraft pack -v
-sudo skopeo --insecure-policy copy oci-archive:sdcore-bess_1.3_amd64.rock docker-daemon:sdcore-bess:1.3
-docker run sdcore-bess:1.3
+sudo skopeo --insecure-policy copy oci-archive:sdcore-upf-bess_1.3_amd64.rock docker-daemon:sdcore-upf-bess:1.3
+docker run sdcore-upf-bess:1.3
 ```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
- # SD-Core BESS ROCK
+ # SD-Core UPF BESS ROCK
 
-Container image for SD-Core BESS, used in SD-Core UPF.
+Container image for SD-Core UPF BESS, used in SD-Core UPF.
 
 ## Usage
 
 ```console
-docker pull ghcr.io/canonical/sdcore-bess:1.3
-docker run -it ghcr.io/canonical/sdcore-bess:1.3
+docker pull ghcr.io/canonical/sdcore-upf-bess:1.3
+docker run -it ghcr.io/canonical/sdcore-upf-bess:1.3
 ```

--- a/local/patches/0001-af_packet-Avoid-set-ioctl-if-there-is-no-flag-diff.patch
+++ b/local/patches/0001-af_packet-Avoid-set-ioctl-if-there-is-no-flag-diff.patch
@@ -1,0 +1,55 @@
+SPDX-License-Identifier: Apache-2.0
+Copyright 2019 Intel Corporation
+
+From e1bc63488d346cb84ae7e76f2bc480247f577abb Mon Sep 17 00:00:00 2001
+From: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
+Date: Fri, 12 Jun 2020 21:36:53 +0000
+Subject: [PATCH] af_packet Avoid set ioctl if there is no flag diff
+
+rte_eth_dev_start -> rte_eth_dev_config_restore
+In 19.11 DPDK started returning errors
+https://github.com/DPDK/dpdk/commit/9039c8125730adfd46b8c891e7f205eb4ac43c67
+https://github.com/DPDK/dpdk/commit/69d0e7092874db1909bc40986c06219f1880dc23
+
+Gist
+https://gist.github.com/krsna1729/0c7160920343f9fa55f760c770286155
+
+We also patch af_packet PMD to change set flags only when needed
+
+Signed-off-by: Saikrishna Edupuganti <saikrishna.edupuganti@intel.com>
+---
+ drivers/net/af_packet/rte_eth_af_packet.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/drivers/net/af_packet/rte_eth_af_packet.c b/drivers/net/af_packet/rte_eth_af_packet.c
+index f5806bf42..29d45eb47 100644
+--- a/drivers/net/af_packet/rte_eth_af_packet.c
++++ b/drivers/net/af_packet/rte_eth_af_packet.c
+@@ -472,6 +472,7 @@ static int
+ eth_dev_change_flags(char *if_name, uint32_t flags, uint32_t mask)
+ {
+ 	struct ifreq ifr;
++	uint32_t cur_flags;
+ 	int ret = 0;
+ 	int s;
+
+@@ -484,8 +485,16 @@ eth_dev_change_flags(char *if_name, uint32_t flags, uint32_t mask)
+ 		ret = -errno;
+ 		goto out;
+ 	}
++
++	cur_flags = ifr.ifr_flags;
+ 	ifr.ifr_flags &= mask;
+ 	ifr.ifr_flags |= flags;
++
++	// Return if there is no change
++	if (cur_flags == ifr.ifr_flags){
++		goto out;
++	}
++
+ 	if (ioctl(s, SIOCSIFFLAGS, &ifr) < 0) {
+ 		ret = -errno;
+ 		goto out;
+--
+2.25.1
+

--- a/local/patches/bpf_validate.patch
+++ b/local/patches/bpf_validate.patch
@@ -1,0 +1,41 @@
+diff --git a/lib/librte_bpf/bpf_impl.h b/lib/librte_bpf/bpf_impl.h
+index b577e2c..f1d6f9a 100644
+--- a/lib/librte_bpf/bpf_impl.h
++++ b/lib/librte_bpf/bpf_impl.h
+@@ -21,7 +21,7 @@ struct rte_bpf {
+ 	uint32_t stack_sz;
+ };
+ 
+-extern int bpf_validate(struct rte_bpf *bpf);
++extern int rte_bpf_validate(struct rte_bpf *bpf);
+ 
+ extern int bpf_jit(struct rte_bpf *bpf);
+ 
+diff --git a/lib/librte_bpf/bpf_load.c b/lib/librte_bpf/bpf_load.c
+index d9d163b..bd9eebf 100644
+--- a/lib/librte_bpf/bpf_load.c
++++ b/lib/librte_bpf/bpf_load.c
+@@ -115,7 +115,7 @@
+ 		return NULL;
+ 	}
+ 
+-	rc = bpf_validate(bpf);
++	rc = rte_bpf_validate(bpf);
+ 	if (rc == 0) {
+ 		bpf_jit(bpf);
+ 		if (mprotect(bpf, bpf->sz, PROT_READ) != 0)
+diff --git a/lib/librte_bpf/bpf_validate.c b/lib/librte_bpf/bpf_validate.c
+index 83983ef..12c34f0 100644
+--- a/lib/librte_bpf/bpf_validate.c
++++ b/lib/librte_bpf/bpf_validate.c
+@@ -2209,7 +2209,7 @@ struct bpf_ins_check {
+ }
+ 
+ int
+-bpf_validate(struct rte_bpf *bpf)
++rte_bpf_validate(struct rte_bpf *bpf)
+ {
+ 	int32_t rc;
+ 	struct bpf_verifier bvf;
+-- 
+

--- a/local/patches/ethdev_include.patch
+++ b/local/patches/ethdev_include.patch
@@ -1,0 +1,26 @@
+diff --git a/lib/librte_ethdev/rte_ethdev.h b/lib/librte_ethdev/rte_ethdev.h
+index d1a593ad1..12a892339 100644
+--- a/lib/librte_ethdev/rte_ethdev.h
++++ b/lib/librte_ethdev/rte_ethdev.h
+@@ -4284,7 +4284,7 @@ __rte_experimental
+ int rte_eth_dev_hairpin_capability_get(uint16_t port_id,
+ 				       struct rte_eth_hairpin_cap *cap);
+ 
+-#include <rte_ethdev_core.h>
++#include "rte_ethdev_core.h"
+ 
+ /**
+  *
+diff --git a/lib/librte_ethdev/rte_ethdev_driver.h b/lib/librte_ethdev/rte_ethdev_driver.h
+index 99d4cd6cd..496c77fb5 100644
+--- a/lib/librte_ethdev/rte_ethdev_driver.h
++++ b/lib/librte_ethdev/rte_ethdev_driver.h
+@@ -15,7 +15,7 @@
+  *
+  */
+ 
+-#include <rte_ethdev.h>
++#include "rte_ethdev.h"
+ 
+ #ifdef __cplusplus
+ extern "C" {

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -20,6 +20,9 @@ parts:
       - libpcap-dev
       - linux-headers-5.4.0-26
       - llvm
+    prime:
+      - usr/local/lib/x86_64-linux-gnu/*.so
+      - usr/lib/libxdp*
 
   cndp:
     after:
@@ -44,6 +47,9 @@ parts:
       make static_build=1 rebuild install
       pushd lang/go/stats/prometheus/
       go build -o $CRAFT_PART_INSTALL/prometheus prometheus.go
+    prime:
+      - usr/local/lib/x86_64-linux-gnu/*.so
+      - usr/local/bin/cndpfwd
 
   dpdk:
     plugin: meson
@@ -79,6 +85,8 @@ parts:
     meson-parameters:
       - --buildtype=debugoptimized
       - -Dmachine=x86-64
+    prime:
+      - usr/local/lib/x86_64-linux-gnu/*.so
 
   bess:
     plugin: nil

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -138,7 +138,6 @@ parts:
       mkdir -p $CRAFT_PART_INSTALL/opt/bess/pybess
       cp -r bessctl/* $CRAFT_PART_INSTALL/opt/bess/bessctl/
       cp -r pybess/* $CRAFT_PART_INSTALL/opt/bess/pybess/
-      cp -r core/pb $CRAFT_PART_INSTALL/pb
 
   bess-python-deps:
     plugin: python

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,0 +1,163 @@
+---
+name: sdcore-bess
+base: ubuntu:20.04
+version: '1.3'
+summary: SD-Core BESS
+description: SD-Core BESS
+license: Apache-2.0
+platforms:
+  amd64:
+
+parts:
+  xdp:
+    plugin: autotools
+    source: https://github.com/xdp-project/xdp-tools.git
+    source-tag: v1.2.2
+    build-packages:
+      - clang
+      - gcc-multilib
+      - libelf-dev
+      - libpcap-dev
+      - linux-headers-5.4.0-26
+      - llvm
+
+  cndp:
+    after:
+      - xdp
+    plugin: nil
+    source: https://github.com/CloudNativeDataPlane/cndp.git
+    source-commit: d5ce4b9edc2e7ddb46a61b395deffafaf11a0500
+    build-environment:
+      - CNE_DEST_DIR: "${CRAFT_PART_INSTALL}"
+    build-packages:
+      - clang
+      - golang
+      - libbpf-dev
+      - libbsd-dev
+      - libnl-3-dev
+      - libnl-cli-3-dev
+      - libnuma-dev
+      - lld
+    override-build: |
+      make
+      make install
+      make static_build=1 rebuild install
+      pushd lang/go/stats/prometheus/
+      go build -o $CRAFT_PART_INSTALL/prometheus prometheus.go
+
+  dpdk:
+    plugin: meson
+    after:
+      - cndp
+    source: https://fast.dpdk.org/rel/dpdk-20.11.3.tar.gz
+    source-type: tar
+    build-packages:
+      - ca-certificates
+      - libbenchmark-dev
+      - libbpf0
+      - libc-ares-dev
+      - libelf-dev
+      - libgflags2.2
+      - libgoogle-glog-dev
+      - libgrpc++-dev
+      - libgtest-dev
+      - libjson-c-dev
+      - libnuma-dev
+      - libpcap-dev
+      - libprotobuf-dev
+      - libunwind-dev
+      - meson
+      - protobuf-compiler
+      - protobuf-compiler-grpc
+      - python3
+    override-pull: |
+      craftctl default
+      for file in ${CRAFT_PROJECT_DIR}/local/patches/*
+      do
+        patch -i $file -p 1
+      done
+    meson-parameters:
+      - --buildtype=debugoptimized
+      - -Dmachine=x86-64
+
+  bess:
+    plugin: nil
+    after:
+      - dpdk
+    source: https://github.com/omec-project/bess.git
+    source-tag: dpdk-2011-focal
+    source-type: git
+    build-packages:
+      - ca-certificates
+      - libbenchmark-dev
+      - libbpf0
+      - libc-ares-dev
+      - libelf-dev
+      - libgflags2.2
+      - libgoogle-glog-dev
+      - libgrpc++-dev
+      - libgtest-dev
+      - libjson-c-dev
+      - libnuma-dev
+      - libpcap-dev
+      - libprotobuf-dev
+      - libssl-dev
+      - libunwind-dev
+      - meson
+      - pkg-config
+      - protobuf-compiler
+      - protobuf-compiler-grpc
+      - python3
+    stage-packages:
+      - libbpf0
+      - libgflags2.2
+      - libjson-c4
+      - libgraph-easy-perl
+      - iproute2
+      - iptables
+      - iputils-ping
+      - tcpdump
+      - ethtool
+    override-build: |
+      for file in $(find ./protobuf -name *.proto -print)
+      do
+        protoc "$file" --proto_path=protobuf --python_out=pybess/builtin_pb --grpc_out=pybess/builtin_pb --plugin=protoc-gen-grpc=$(which grpc_python_plugin)
+      done
+      make -C core bessd modules
+      mkdir -p $CRAFT_PART_INSTALL/bin
+      cp bin/bessd $CRAFT_PART_INSTALL/bin/bessd
+      mkdir -p $CRAFT_PART_INSTALL/opt/bess/bessctl
+      mkdir -p $CRAFT_PART_INSTALL/opt/bess/pybess
+      cp -r bessctl/* $CRAFT_PART_INSTALL/opt/bess/bessctl/
+      cp -r pybess/* $CRAFT_PART_INSTALL/opt/bess/pybess/
+      cp -r core/pb $CRAFT_PART_INSTALL/pb
+
+  bess-python-deps:
+    plugin: python
+    after:
+      - bess
+    source: .
+    python-packages:
+      - flask
+      - grpcio
+      - iptools
+      - mitogen
+      - protobuf==3.20.0
+      - psutil
+      - pyroute2
+      - scapy
+    stage-packages:
+      - python3-venv
+    override-build: |
+      craftctl default
+      ln -srf $CRAFT_PART_INSTALL/bin/python3 $CRAFT_PART_INSTALL/bin/python
+
+  config:
+    plugin: nil
+    after:
+      - bess
+    source: https://github.com/omec-project/upf.git
+    source-commit: 57860858a17088d06c6bc0def9fcd6e6697a1e98
+    override-build: |
+      mkdir -p $CRAFT_PART_INSTALL/opt/bess/bessctl/conf
+      cp -r conf/* $CRAFT_PART_INSTALL/opt/bess/bessctl/conf/

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -27,7 +27,7 @@ parts:
   cndp:
     after:
       - xdp
-    plugin: nil
+    plugin: make
     source: https://github.com/CloudNativeDataPlane/cndp.git
     source-commit: d5ce4b9edc2e7ddb46a61b395deffafaf11a0500
     build-environment:
@@ -42,11 +42,8 @@ parts:
       - libnuma-dev
       - lld
     override-build: |
-      make
-      make install
+      craftctl default
       make static_build=1 rebuild install
-      pushd lang/go/stats/prometheus/
-      go build -o $CRAFT_PART_INSTALL/prometheus prometheus.go
     prime:
       - usr/local/lib/x86_64-linux-gnu/*.so
       - usr/local/bin/cndpfwd

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,9 +1,9 @@
 ---
-name: sdcore-bess
+name: sdcore-upf-bess
 base: ubuntu:20.04
 version: '1.3'
-summary: SD-Core BESS
-description: SD-Core BESS
+summary: SD-Core UPF BESS
+description: SD-Core UPF BESS
 license: Apache-2.0
 platforms:
   amd64:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -160,11 +160,11 @@ parts:
       ln -srf $CRAFT_PART_INSTALL/bin/python3 $CRAFT_PART_INSTALL/bin/python
 
   config:
-    plugin: nil
+    plugin: dump
     after:
       - bess
     source: https://github.com/omec-project/upf.git
     source-commit: 57860858a17088d06c6bc0def9fcd6e6697a1e98
-    override-build: |
-      mkdir -p $CRAFT_PART_INSTALL/opt/bess/bessctl/conf
-      cp -r conf/* $CRAFT_PART_INSTALL/opt/bess/bessctl/conf/
+    source-subdir: conf
+    organize:
+      "*": opt/bess/bessctl/conf/


### PR DESCRIPTION
# Description

Add initial rockcraft.yaml for BESS. This initial version was tested working as a drop-in replacement for the upstream image for both UPF's `bessd` and `routectl` containers.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
