### PR TITLE
Drop CPU requirements to Haswell to remove RDSEED requirement

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -41,7 +41,7 @@ parts:
       - lld
     meson-parameters:
       - -Dbuildtype=release
-      - -Dmachine=skylake
+      - -Dmachine=haswell
       - -Ddefault_library=static
     override-build: |
       craftctl default
@@ -82,7 +82,7 @@ parts:
       done
     meson-parameters:
       - --buildtype=debugoptimized
-      - -Dmachine=skylake
+      - -Dmachine=haswell
     prime:
       - usr/local/lib/x86_64-linux-gnu/*.so
 


### PR DESCRIPTION
# Description

Drop CPU requirements to Haswell to remove RDSEED requirement. This should help with the integration tests when certain runners can be dispatched on older machines not supporting the instruction set.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
