### PR TITLE
chore: Uses new rockcraft.yaml syntax for base

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,6 +1,6 @@
 ---
 name: sdcore-upf-bess
-base: ubuntu:20.04
+base: ubuntu@20.04
 version: '1.3'
 summary: SD-Core UPF BESS
 description: SD-Core UPF BESS


### PR DESCRIPTION
# Description

The way the base image is represented in rockcraft.yaml has recently changed. This PR uses the new way to specify base image.

## Reference
- https://canonical-rockcraft.readthedocs-hosted.com/en/latest/reference/rockcraft.yaml/

## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
