### PR TITLE
fix: Adding missing jsoncomment dependency

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -146,6 +146,7 @@ parts:
       - flask
       - grpcio
       - iptools
+      - jsoncomment
       - mitogen
       - protobuf==3.20.0
       - psutil


### PR DESCRIPTION
# Description

Latest code changes in the upstream, require `jsoncomment`. 
This PR is adding it to the rock.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have made corresponding changes to the documentation.
- [x] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
