### PR TITLE
chore: use release version of sdcore github workflows

### DIFF
--- a/.github/workflows/dependabot_pr.yaml
+++ b/.github/workflows/dependabot_pr.yaml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   auto-merge:
-    uses: canonical/sdcore-github-workflows/.github/workflows/dependabot_pr.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/dependabot_pr.yaml@v0.0.1

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -7,5 +7,5 @@ on:
 jobs:
   update:
     name: Update Issue
-    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/issues.yaml@v0.0.1
     secrets: inherit

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -8,13 +8,13 @@ on:
 jobs:
 
   build-rock:
-    uses: canonical/sdcore-github-workflows/.github/workflows/build-rock.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/build-rock.yaml@v0.0.1
 
   scan-rock:
     needs: build-rock
-    uses: canonical/sdcore-github-workflows/.github/workflows/scan-rock.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/scan-rock.yaml@v0.0.1
 
   publish-rock:
     if: github.ref_name == 'main'
     needs: scan-rock
-    uses: canonical/sdcore-github-workflows/.github/workflows/publish-rock.yaml@main
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-rock.yaml@v0.0.1


### PR DESCRIPTION
# Description

Use the release version of sdcore-github workflows instead of using the main branch.

## Rationale

This will allow to make breaking changes in the workflows without breaking its dependents. More specifically, we are working on building the charm in its independent workflow step instead of having it built in the integration tests. Making such change in the workflows would break every NF CI until they adapt to the new workflow approach. Here we want to avoid this and have the workflow keep on working until we intentionally adopt the new approach.


## Checklist

- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
