### PR TITLE
fix: Fix bessctl show pipeline command

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -127,6 +127,7 @@ parts:
       - libelf1
       - libgflags2.2
       - libgoogle-glog0v5
+      - libgraph-easy-perl
       - libgrpc++1
       - libjson-c5
       - libnl-3-200


### PR DESCRIPTION
# Description

Adds missing package for the `show pipeline` command to work in `bessctl`, that can be useful for debugging BESS configuration issues.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [x] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
