### PR TITLE
fix: Follow UPF versioning instead of BESS versioning to match upstream

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -1,7 +1,7 @@
 ---
 name: sdcore-upf-bess
 base: ubuntu@24.04
-version: '1.0.1'
+version: '1.5.0'
 summary: SD-Core UPF BESS
 description: SD-Core UPF BESS
 license: Apache-2.0
@@ -96,7 +96,7 @@ parts:
     after:
       - dpdk
     source: https://github.com/omec-project/bess.git
-    source-tag: v${CRAFT_PROJECT_VERSION}
+    source-tag: v1.0.1
     source-type: git
     build-packages:
       - ca-certificates
@@ -192,7 +192,7 @@ parts:
     after:
       - bess
     source: https://github.com/omec-project/upf.git
-    source-tag: v1.5.0
+    source-tag: v${CRAFT_PROJECT_VERSION}
     source-subdir: conf
     organize:
       "*": opt/bess/bessctl/conf/


### PR DESCRIPTION
# Description

Upstream versions the image for the UPF using the version of the UPF project. This PR does the same for our rock, making it clearer what version we are running.

## Checklist

- [x] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have added tests that validate the behaviour of the software.
- [ ] I validated that new and existing tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
